### PR TITLE
Efficient implementation of Halton draws generation

### DIFF
--- a/biogeme/draws.py
+++ b/biogeme/draws.py
@@ -198,22 +198,24 @@ def getHaltonDraws(
         raise excep.biogemeError(
             f'Invalid sample size: {sampleSize} when generating draws.'
         )
-    totalSize = numberOfDraws * sampleSize
+    length = numberOfDraws * sampleSize
+    req_length = length + skip + 1
+    numbers = np.empty(req_length)
+    numbers[0] = 0
+    numbers_idx = 1
+    t = 1
+    while numbers_idx < req_length:
+        d = 1/base**t
+        numbers_size = numbers_idx
+        i = 1
+        while i < base and numbers_idx < req_length:
+            max_numbers = min(req_length - numbers_idx, numbers_size)
+            numbers[numbers_idx: numbers_idx + max_numbers] = numbers[:max_numbers] + d * i
+            numbers_idx += max_numbers
+            i += 1
+        t += 1
+    numbers = numbers[skip + 1:length + skip + 1]
 
-    numbers = []
-    skipped = 0
-    for i in range(totalSize + 1 + skip):
-        n, denom = 0.0, 1.0
-        while i > 0:
-            i, remainder = divmod(i, base)
-            denom *= base
-            n += remainder / denom
-        if skipped < skip:
-            skipped += 1
-        else:
-            numbers.append(n)
-
-    numbers = np.array(numbers[1:])
     if shuffled:
         np.random.shuffle(numbers)
 


### PR DESCRIPTION
I have developed an efficient implementation of a Halton Draws generation function that can be easily integrated into Biogeme. A benchmark I conducted suggests that this new implementation is, on average, 500x faster than the current Biogeme's implementation (please see plot below and the attached Jupyter Notebook). Also, this new implementation escalates very well with the number of draws, while using the same amount of RAM memory of Biogeme's implementation. This new implementation takes advantage of the fact that every step of the generation of a Halton sequence can be expressed as the sum of the previous values in the sequence plus a set of new dividing points, as explained by Dr. Train in his manuscript "Halton Sequences for Mixed Logit" (Page 4 of https://eml.berkeley.edu/wp/train0899.pdf). These iterative summations can be conveniently and efficiently handled as NumPy array operations. Given that I do not use any intermediate arrays, memory usage is very efficient.

![halton_draws_benchmark](https://user-images.githubusercontent.com/13966395/140742746-ac6d759c-4e8c-4847-bcc5-b856342fcf6d.png)


[halton_benchmark_ipynb.zip](https://github.com/michelbierlaire/biogeme/files/7496974/halton_benchmark_ipynb.zip)


