### PR TITLE
CI: Specify Python version, add cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - run: pip install wheel
-    - run: pip install pipenv
+      with:
+        python-version: '3.9'
+        cache: 'pipenv'
+    - run: pip install -U wheel pipenv
     - run: pipenv install --dev --system
     - run: python setup.py install
     - run: pytest tests/simple_test.py


### PR DESCRIPTION
Fixes the current CI setup, since it was broken when it switched automatically to Python 3.10 in the actions/setup-python@v2 step.
- Specify the Python version to setup, currently to 3.9
- Cache the pipenv packages
- Install wheel en pipenv in single step, and upgrade them to the latest version