### PR TITLE
Corrected Knapsack inheritance class name

### DIFF
--- a/examples/vns/knapsack.py
+++ b/examples/vns/knapsack.py
@@ -156,7 +156,7 @@ def change_decisions(element, size=1):
     return neighbor.get_element(), n
 
 
-class Knapsack(vns.ProblemClass):
+class Knapsack(vns.problemClass):
     """Class defining the knapsack problem. Note the inheritance from the
     abstract class used by the VNS algorithm. It guarantees the
     compliance with the requirements of the algorithm.


### PR DESCRIPTION
I wasn't able to import the Knapsack example because of a error in the class' definition.
I made the following change in knapsack.py
ProblemClass -> problemClass