### PR TITLE
CI: Run tests once a week and don't cancel early

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,12 +9,16 @@ on:
     branches:
       - master
       - develop
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   test:
     name: Tests
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ['3.12', '3.11', '3.10']


### PR DESCRIPTION
Two small changes to the CI configuration:
- Run the tests once a week (each Monday 06:00 UTC), and when manually triggered ([docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatch))
- Continue running the tests until they fail (to see the proper error codes) ([docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast))